### PR TITLE
add a export statement in ssh command

### DIFF
--- a/judge_server.py
+++ b/judge_server.py
@@ -20,7 +20,7 @@ def send(ofp, lname, rname):
 
 def work(sid, pid, lng, serv):
 	print(sid, pid, lng, file = sys.stderr)
-	p = subprocess.Popen(['ssh', serv, 'butler'], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
+        p = subprocess.Popen(['ssh', serv, 'export PATH=$PATH:/home/butler; butler'], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
 	ifp = p.stdout
 	ofp = p.stdin
 	send(ofp, './const.py', 'const.py')


### PR DESCRIPTION
[直接以ssh執行指令時，並不會source到\~/.bashrc中的內容](http://unix.stackexchange.com/questions/15207/dot-file-not-sourced-when-running-a-command-via-ssh)，因此需要在執行指令前先source \~/.bashrc或是直接export PATH參數，這邊採用的是後者的作法，這樣一來就不需要建立\~/.bashrc。